### PR TITLE
CI: modernize workflow (netlify-cli 21.6.0, action bumps)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,7 @@ jobs:
           netlify deploy \
             --alias ${{ env.BRANCH_NAME_SLUG }} \
             --dir ./build \
+            --no-build \
             --message 'Preview deployment for ${{ steps.slug.outputs.branch-name }} (${{ env.GITHUB_SHA_SHORT }})' \
             --json
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,13 +9,13 @@ jobs:
     if: github.ref != 'refs/heads/prod' && github.actor != 'dependabot[bot]'
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '18'
 
       # @see https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache-node-modules
         with:
           path: ./node_modules
@@ -75,13 +75,13 @@ jobs:
     if: github.ref == 'refs/heads/prod' && github.actor != 'dependabot[bot]'
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '18'
 
       # @see https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         id: cache-node-modules
         with:
           path: ./node_modules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,11 +36,15 @@ jobs:
       - name: Build
         run: npm run build
 
-      # Pin netlify-cli
-      # @see https://github.com/netlify/cli/issues/6841
+      # Pin netlify-cli for reproducible builds. Bumped 17.36.1 -> 21.6.0:
+      # the old pin avoided the "Multiple possible build commands" regression
+      # from 17.36.2 (netlify/cli#6841, since fixed), but it dragged in an old
+      # sharp that downloaded libvips at install time and flaked on network
+      # errors (ECONNRESET). 21.6.0 dropped that sharp dependency and is the
+      # newest release still compatible with Node 18.
       - name: Install netlify-cli
         shell: bash
-        run: npm i -g netlify-cli@17.36.1
+        run: npm i -g netlify-cli@21.6.0
 
       # Use netlify-cli for deployment
       # @see https://cli.netlify.com/commands/deploy/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
             --alias ${{ env.BRANCH_NAME_SLUG }} \
             --dir ./build \
             --message 'Preview deployment for ${{ steps.slug.outputs.branch-name }} (${{ env.GITHUB_SHA_SHORT }})' \
-            --json true
+            --json
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
Modernizes the CI workflow and fixes the Netlify preview deploy.

### netlify-cli
- Bump pinned `netlify-cli` `17.36.1` -> `21.6.0`. The old pin dodged the "Multiple possible build commands" regression from `17.36.2` (netlify/cli#6841, since fixed) but dragged in an old `sharp` that downloads libvips at install time and intermittently failed with `ECONNRESET`. Modern netlify-cli dropped `sharp`; `21.6.0` is the newest release still compatible with **Node 18** (22.x needs Node >=20.12.2).
- `--json true` -> `--json` (21.x treats it as a strict boolean; the stray `true` caused a silent exit 2).
- Added `--no-build` (21.x runs a build on deploy by default and would run the site's `hugo` build command; we already build in the Build step and only upload `./build`).

### GitHub Actions bumps (supersedes #18, #19, #20)
- `actions/checkout` v3 -> v6
- `actions/setup-node` v3 -> v6
- `actions/cache` -> v5, unified across both jobs (the prod job was on `@v3`, whose backend GitHub retired, so its cache was broken).

Verified end to end: preview deploy is green and the site serves at `ci-bump-netlify-cli--inventage-tech-radar.netlify.app`.

### Follow-up (not in this PR)
Node 18 is EOL. Bumping to Node 20/22 would allow netlify-cli latest (26.x) but risks the radar build, so it's left as a separate decision.