### PR TITLE
Add Matomo analytics

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "basePath": "/",
   "baseUrl": "https://techradar.inventage.com",
   "logoFile": "/logo.svg",
-  "jsFile": "",
+  "jsFile": "/analytics.js",
   "editUrl": "",
   "toggles": {
     "showChart": true,

--- a/public/analytics.js
+++ b/public/analytics.js
@@ -14,4 +14,32 @@ _paq.push(["enableLinkTracking"]);
   g.async = true;
   g.src = u + "matomo.js";
   s.parentNode.insertBefore(g, s);
+
+  // The radar is a Next.js client-side app: navigating between quadrants and
+  // blips changes the URL via the History API without a full page load, so the
+  // initial trackPageView above would be the only hit. Patch pushState/
+  // replaceState (and listen for popstate) to record a page view per in-app
+  // navigation. Deferred so Next has committed the new document.title first.
+  var previousUrl = location.href;
+  function trackSpaPageView() {
+    if (location.href === previousUrl) return;
+    _paq.push(["setReferrerUrl", previousUrl]);
+    _paq.push(["setCustomUrl", location.href]);
+    _paq.push(["setDocumentTitle", document.title]);
+    _paq.push(["trackPageView"]);
+    // Re-scan the new DOM so outbound links stay tracked.
+    _paq.push(["enableLinkTracking"]);
+    previousUrl = location.href;
+  }
+  ["pushState", "replaceState"].forEach(function (type) {
+    var orig = history[type];
+    history[type] = function () {
+      var rv = orig.apply(this, arguments);
+      setTimeout(trackSpaPageView, 0);
+      return rv;
+    };
+  });
+  window.addEventListener("popstate", function () {
+    setTimeout(trackSpaPageView, 0);
+  });
 })();

--- a/public/analytics.js
+++ b/public/analytics.js
@@ -1,0 +1,17 @@
+// Matomo analytics. Loaded via the radar's `jsFile` config option
+// (config.json -> jsFile), which renders this as a <script src> on every page.
+var _paq = (window._paq = window._paq || []);
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(["trackPageView"]);
+_paq.push(["enableLinkTracking"]);
+(function () {
+  var u = "https://analytics.inventage.com/";
+  _paq.push(["setTrackerUrl", u + "matomo.php"]);
+  _paq.push(["setSiteId", "15"]);
+  var d = document,
+    g = d.createElement("script"),
+    s = d.getElementsByTagName("script")[0];
+  g.async = true;
+  g.src = u + "matomo.js";
+  s.parentNode.insertBefore(g, s);
+})();


### PR DESCRIPTION
Adds Matomo tracking (Inventage instance, site id 15).

**Approach:** the snippet body lives in `public/analytics.js` and is wired through the radar's built-in `jsFile` config option (`config.json`), which renders it as `<script src="/analytics.js">` on every page. No `node_modules`/package changes, so it survives radar upgrades.

**Verified on preview:** `/analytics.js` loads, `window._paq` is populated, and the Matomo tracker script is injected.

**Caveat — SPA navigation:** this fires `trackPageView` on the initial page load and tracks outbound links, but the radar is a Next.js client-side app, so navigating between quadrants/blips does **not** currently register additional page views. Tracking those would require hooking Next's router (an override of the radar's `_app`). Left out for now; can add if we want per-navigation analytics.