### PR TITLE
Point footer legal link to Inventage privacy policy

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
   "logoFile": "/logo.svg",
   "jsFile": "/analytics.js",
   "editUrl": "",
+  "imprint": "https://inventage.com/firma/datenschutzerklaerung",
   "toggles": {
     "showChart": true,
     "showTagFilter": true,


### PR DESCRIPTION
The footer 'Legal Information' link had no `imprint` override in `config.json`, so it fell back to the AOE package default (`aoe.com/en/imprint.html`). Points it at Inventage's Datenschutzerklaerung.

Verified on preview: footer link -> `https://inventage.com/firma/datenschutzerklaerung`.