### PR TITLE
Label footer legal link 'Datenschutzerklärung'

### DIFF
--- a/config.json
+++ b/config.json
@@ -115,6 +115,7 @@
   ],
   "labels": {
     "title": "Inventage Tech-Radar",
+    "imprint": "Datenschutzerklärung",
     "quadrant": "Quadrant",
     "quadrantOverview": "Quadrant Übersicht",
     "zoomIn": "Vergrössern",


### PR DESCRIPTION
Follow-up to #25. The footer link points to Inventage's privacy policy, so replace the AOE default English label 'Legal Information' with the German 'Datenschutzerklärung' (via config `labels.imprint`).